### PR TITLE
Fix profile table references and add join group page

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -93,7 +93,7 @@ function SignupForm() {
 
         // Update username in people table
         const { error: updateError } = await supabase
-          .from('people')
+          .from('user_profiles')
           .update({ username: username })
           .eq('userid', authData.user.id);
 

--- a/src/hooks/useMembers.ts
+++ b/src/hooks/useMembers.ts
@@ -26,7 +26,7 @@ export function useMembers(groupId: string) {
           .from('peoplegroup')
           .select(`
             users_userid,
-            people:users_userid (
+            user_profiles:users_userid (
               userid,
               username
             )
@@ -38,7 +38,7 @@ export function useMembers(groupId: string) {
         } else {
           const membersList = data?.map(item => ({
             id: item.users_userid,
-            username: (item.people as any)?.username || 'Unknown',
+            username: (item.user_profiles as any)?.username || 'Unknown',
           })) || [];
           setMembers(membersList);
         }
@@ -68,7 +68,7 @@ export function useMembers(groupId: string) {
         .from('peoplegroup')
         .select(`
           users_userid,
-          people:users_userid (
+          user_profiles:users_userid (
             userid,
             username
           )
@@ -78,7 +78,7 @@ export function useMembers(groupId: string) {
       if (data) {
         const membersList = data?.map(item => ({
           id: item.users_userid,
-          username: (item.people as any)?.username || 'Unknown',
+          username: (item.user_profiles as any)?.username || 'Unknown',
         })) || [];
         setMembers(membersList);
       }

--- a/src/hooks/usePairingHistory.ts
+++ b/src/hooks/usePairingHistory.ts
@@ -56,7 +56,7 @@ export function usePairingHistory(groupId: string, userId?: string | null) {
               .from('peopledinner')
               .select(`
                 users_userid,
-                people:users_userid (
+                user_profiles:users_userid (
                   userid,
                   username
                 )
@@ -77,7 +77,7 @@ export function usePairingHistory(groupId: string, userId?: string | null) {
               } : undefined,
               attendees: attendees?.map(a => ({
                 userid: a.users_userid,
-                username: (a.people as any)?.username || 'Unknown'
+                username: (a.user_profiles as any)?.username || 'Unknown'
               })) || []
             };
           })

--- a/src/hooks/usePairings.ts
+++ b/src/hooks/usePairings.ts
@@ -59,7 +59,7 @@ export function usePairings() {
         .from('peoplegroup')
         .select(`
           users_userid,
-          people:users_userid (
+          user_profiles:users_userid (
             userid,
             username
           )
@@ -142,7 +142,7 @@ export function usePairings() {
       // Step 5: Generate optimal pairs
       const userList = members.map(m => ({
         userid: m.users_userid,
-        username: (m.people as any).username
+        username: (m.user_profiles as any).username
       }));
 
       const pairs: PairResult[] = [];

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -29,7 +29,7 @@ export function useProfile() {
         }
 
         const { data, error } = await supabase
-          .from('people')
+          .from('user_profiles')
           .select('*')
           .eq('userid', user.id)
           .single();
@@ -58,7 +58,7 @@ export function useProfile() {
       logger.info('Updating profile', { userId: user.id, fields: Object.keys(updates) });
 
       const { data, error } = await supabase
-        .from('people')
+        .from('user_profiles')
         .update({ ...updates, updated_at: new Date().toISOString() })
         .eq('userid', user.id)
         .select()


### PR DESCRIPTION
## Summary

This PR includes two main features:

### 1. Fix `/profile` Error - Table Not Found
**Issue:** App was querying a `people` table that doesn't exist in the database. The correct table is `user_profiles`.

**Fixed:**
- `useProfile` hook now queries `user_profiles`
- `useMembers`, `usePairings`, `usePairingHistory` hooks updated to use correct join syntax
- Signup page username update fixed
- Resolves "table public.people not found" error

### 2. Standardize Card Styling & Add Join Group Page
**Card Styling:**
- Replaced `Card` component in `GroupCard` with inline styles matching the manage page
- All group cards on `/groups` now have consistent rounded corners, transparent background, 2px gold border

**Join Group Page (`/join`):**
- New page for manually entering a 24-character invite code
- Three-step flow: code entry → group preview → success/redirect
- Auth-gated with redirect back after login
- `useJoinGroup` hook handles validation and join logic
- `joinGroupContent` file centralizes all copy
- "Join with Code" button added to groups page navigation

## Test Plan

- [ ] Visit `/profile` — no "table not found" error
- [ ] `/groups` — cards show rounded corners, transparent bg, gold border, spacing
- [ ] `/groups/[id]/manage` — sections look identical to before (no regression)
- [ ] `/join` while logged out — redirects to login, returns after auth
- [ ] Enter code <24 or >24 chars — shows format error
- [ ] Enter valid 24-char code — shows group preview
- [ ] Click "Join Group" — adds user to group, redirects to `/groups/[id]/members`
- [ ] Enter invalid/expired code — shows appropriate error
- [ ] "Join with Code" button visible on `/groups` page

Closes #24