### PR TITLE
Fix: Replace 'people' table references with 'user_profiles'

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -99,7 +99,7 @@ function SignupForm() {
 
         // Update username in people table
         const { error: updateError } = await supabase
-          .from('people')
+          .from('user_profiles')
           .update({ username: username })
           .eq('userid', authData.user.id);
 

--- a/src/hooks/useMembers.ts
+++ b/src/hooks/useMembers.ts
@@ -26,7 +26,7 @@ export function useMembers(groupId: string) {
           .from('peoplegroup')
           .select(`
             users_userid,
-            people:users_userid (
+            user_profiles:users_userid (
               userid,
               username
             )
@@ -38,7 +38,7 @@ export function useMembers(groupId: string) {
         } else {
           const membersList = data?.map(item => ({
             id: item.users_userid,
-            username: (item.people as any)?.username || 'Unknown',
+            username: (item.user_profiles as any)?.username || 'Unknown',
           })) || [];
           setMembers(membersList);
         }
@@ -68,7 +68,7 @@ export function useMembers(groupId: string) {
         .from('peoplegroup')
         .select(`
           users_userid,
-          people:users_userid (
+          user_profiles:users_userid (
             userid,
             username
           )
@@ -78,7 +78,7 @@ export function useMembers(groupId: string) {
       if (data) {
         const membersList = data?.map(item => ({
           id: item.users_userid,
-          username: (item.people as any)?.username || 'Unknown',
+          username: (item.user_profiles as any)?.username || 'Unknown',
         })) || [];
         setMembers(membersList);
       }

--- a/src/hooks/usePairingHistory.ts
+++ b/src/hooks/usePairingHistory.ts
@@ -56,7 +56,7 @@ export function usePairingHistory(groupId: string, userId?: string | null) {
               .from('peopledinner')
               .select(`
                 users_userid,
-                people:users_userid (
+                user_profiles:users_userid (
                   userid,
                   username
                 )
@@ -77,7 +77,7 @@ export function usePairingHistory(groupId: string, userId?: string | null) {
               } : undefined,
               attendees: attendees?.map(a => ({
                 userid: a.users_userid,
-                username: (a.people as any)?.username || 'Unknown'
+                username: (a.user_profiles as any)?.username || 'Unknown'
               })) || []
             };
           })

--- a/src/hooks/usePairings.ts
+++ b/src/hooks/usePairings.ts
@@ -59,7 +59,7 @@ export function usePairings() {
         .from('peoplegroup')
         .select(`
           users_userid,
-          people:users_userid (
+          user_profiles:users_userid (
             userid,
             username
           )
@@ -142,7 +142,7 @@ export function usePairings() {
       // Step 5: Generate optimal pairs
       const userList = members.map(m => ({
         userid: m.users_userid,
-        username: (m.people as any).username
+        username: (m.user_profiles as any).username
       }));
 
       const pairs: PairResult[] = [];

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -29,7 +29,7 @@ export function useProfile() {
         }
 
         const { data, error } = await supabase
-          .from('people')
+          .from('user_profiles')
           .select('*')
           .eq('userid', user.id)
           .single();
@@ -58,7 +58,7 @@ export function useProfile() {
       logger.info('Updating profile', { userId: user.id, fields: Object.keys(updates) });
 
       const { data, error } = await supabase
-        .from('people')
+        .from('user_profiles')
         .update({ ...updates, updated_at: new Date().toISOString() })
         .eq('userid', user.id)
         .select()


### PR DESCRIPTION
## Summary

Fixes the `/profile` page error: **"Could not find the table 'public.people' in the schema cache"**

The codebase was querying a `people` table that doesn't exist in the database. The correct table name is `user_profiles`.

## Changes

- **`src/hooks/useProfile.ts`** — Query `user_profiles` instead of `people`
- **`src/hooks/useMembers.ts`** — Join syntax changed to `user_profiles:users_userid`
- **`src/hooks/usePairings.ts`** — Updated join references
- **`src/hooks/usePairingHistory.ts`** — Updated join references
- **`src/app/signup/page.tsx`** — Update username in `user_profiles` table

## Test Plan

- [ ] Visit `/profile` — no "table not found" error
- [ ] Profile data loads correctly
- [ ] Username updates work on signup
- [ ] Group members display correctly on `/groups/[id]/members`
- [ ] Pairing history shows partner names correctly

## Database Schema Reference

The correct table is `user_profiles` with columns:
- `userid` (uuid, primary key)
- `username` (varchar)
- `created_at`, `updated_at` (timestamps)
- Plus other profile fields (bio, occupation, interests, etc.)