### PR TITLE
Add post-save availability confirmation page with partner view

### DIFF
--- a/src/app/groups/[id]/availability/confirmation/page.tsx
+++ b/src/app/groups/[id]/availability/confirmation/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { PageContainer, PageHeader, Button, Footer, PageLoading } from '@/components';
+import { useAvailability, usePairedMemberAvailability } from '@/hooks';
+import { availabilityConfirmationContent as c } from '@/content/availabilityConfirmation';
+import { availabilityContent } from '@/content/availability';
+import type { PairedPartner } from '@/hooks/usePairedMemberAvailability';
+
+const { days, months } = availabilityContent.calendar;
+
+const cardStyle: React.CSSProperties = {
+  width: '100%',
+  backgroundColor: 'transparent',
+  border: '2px solid #FBE6A6',
+  borderRadius: '12px',
+  padding: '16px',
+  marginBottom: '16px',
+};
+
+function formatDateLabel(dateKey: string) {
+  const d = new Date(`${dateKey}T00:00:00`);
+  return `${days[d.getDay()]}, ${months[d.getMonth()]} ${d.getDate()}`;
+}
+
+function SlotChip({ label }: { label: string }) {
+  return (
+    <span
+      style={{
+        backgroundColor: 'rgba(251,230,166,0.15)',
+        color: '#FBE6A6',
+        border: '1px solid rgba(251,230,166,0.4)',
+        borderRadius: '20px',
+        padding: '4px 12px',
+        fontSize: '12px',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function AvailabilityDateList({ availability }: { availability: Record<string, string[] | Set<string>> }) {
+  const sortedDates = Object.keys(availability).sort();
+  if (sortedDates.length === 0) {
+    return <p style={{ color: '#F8F4F0', fontSize: '14px' }}>{c.noAvailability}</p>;
+  }
+  return (
+    <>
+      {sortedDates.map(dateKey => {
+        const slots = Array.from(availability[dateKey]);
+        return (
+          <div key={dateKey} style={{ marginBottom: '10px' }}>
+            <p style={{ color: '#F8F4F0', fontSize: '13px', fontWeight: 600, marginBottom: '4px' }}>
+              {formatDateLabel(dateKey)}
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+              {slots.map(slot => <SlotChip key={slot} label={c.timeLabel(slot)} />)}
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function PartnerCard({ partner }: { partner: PairedPartner }) {
+  return (
+    <div style={cardStyle}>
+      <p style={{ color: '#FBE6A6', fontWeight: 700, fontSize: '16px', marginBottom: '12px' }}>
+        {c.partnerSection.title(partner.username)}
+      </p>
+      {Object.keys(partner.availability).length === 0 ? (
+        <p style={{ color: '#F8F4F0', fontSize: '14px' }}>{c.partnerSection.noSlots}</p>
+      ) : (
+        <AvailabilityDateList availability={partner.availability} />
+      )}
+    </div>
+  );
+}
+
+export default function AvailabilityConfirmationPage() {
+  const params = useParams();
+  const router = useRouter();
+  const groupId = params?.id as string;
+
+  const { availability, loading: availLoading } = useAvailability(groupId);
+  const { partners, hasPairing, loading: pairingLoading, error } = usePairedMemberAvailability(groupId);
+
+  if (availLoading || pairingLoading) return <PageLoading message="Loading your availability..." />;
+
+  return (
+    <PageContainer>
+      <div
+        style={{
+          flex: 1,
+          width: '100%',
+          maxWidth: '500px',
+          margin: '0 auto',
+          padding: '48px 16px 150px 16px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <PageHeader>{c.title}</PageHeader>
+        <p style={{ color: '#F8F4F0', textAlign: 'center', marginBottom: '32px', fontSize: '14px' }}>
+          {c.subtitle}
+        </p>
+
+        {/* ── Your submitted availability ─────────────────────────────────── */}
+        <div style={cardStyle}>
+          <p style={{ color: '#FBE6A6', fontWeight: 700, fontSize: '16px', marginBottom: '12px' }}>
+            {c.yourSection.title}
+          </p>
+          <AvailabilityDateList availability={availability} />
+        </div>
+
+        {/* ── Paired partner availability (or waiting state) ──────────────── */}
+        {error ? (
+          <div style={{ ...cardStyle, borderColor: '#f87171' }}>
+            <p style={{ color: '#f87171', fontWeight: 700, fontSize: '16px', marginBottom: '8px' }}>
+              {c.errorState.title}
+            </p>
+            <p style={{ color: '#F8F4F0', fontSize: '14px' }}>{c.errorState.description}</p>
+          </div>
+        ) : hasPairing ? (
+          partners.map(partner => <PartnerCard key={partner.userId} partner={partner} />)
+        ) : (
+          <div style={cardStyle}>
+            <p style={{ color: '#FBE6A6', fontWeight: 700, fontSize: '16px', marginBottom: '8px' }}>
+              {c.waitingState.title}
+            </p>
+            <p style={{ color: '#F8F4F0', fontSize: '14px' }}>{c.waitingState.description}</p>
+          </div>
+        )}
+
+        <Button onClick={() => router.push(`/groups/${groupId}/manage`)}>
+          {c.buttons.returnToGroup}
+        </Button>
+        <Button variant="secondary" onClick={() => router.push(`/groups/${groupId}/availability`)}>
+          {c.buttons.edit}
+        </Button>
+      </div>
+      <Footer />
+    </PageContainer>
+  );
+}

--- a/src/content/availabilityConfirmation.ts
+++ b/src/content/availabilityConfirmation.ts
@@ -1,0 +1,39 @@
+const TIME_LABELS: Record<string, string> = {
+  breakfast: 'Breakfast (8–10am)',
+  lunch: 'Lunch (12–2pm)',
+  dinner: 'Dinner (6–9pm)',
+  late_night: 'Late Night (9pm+)',
+};
+
+export const availabilityConfirmationContent = {
+  title: 'Availability Saved',
+  subtitle: "You're all set! We'll reach out once pairings are confirmed.",
+
+  yourSection: {
+    title: 'Your Availability',
+  },
+
+  noAvailability: 'No dates selected.',
+
+  partnerSection: {
+    title: (name: string) => `${name}'s Availability`,
+    noSlots: "They haven't submitted availability yet.",
+  },
+
+  waitingState: {
+    title: 'Waiting for Pairings',
+    description: "Your availability has been saved. Once the admin creates pairings, you'll be able to see your dinner partner's schedule here.",
+  },
+
+  errorState: {
+    title: 'Could Not Load Partner Availability',
+    description: "There was a problem fetching your partner's schedule. Try refreshing the page.",
+  },
+
+  buttons: {
+    returnToGroup: 'Back to Group',
+    edit: 'Edit Availability',
+  },
+
+  timeLabel: (slot: string) => TIME_LABELS[slot] ?? slot,
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,9 +7,11 @@ export { usePairingHistory } from './usePairingHistory';
 export { useGroupAdmin } from './useGroupAdmin';
 export { useJoinGroup } from './useJoinGroup';
 export { useAvailability } from './useAvailability';
+export { usePairedMemberAvailability } from './usePairedMemberAvailability';
 
 export type { Profile } from './useProfile';
 export type { AvailabilityMap, MemberAvailabilitySummary, TimeSlot } from './useAvailability';
+export type { PairedPartner, PairedMemberAvailabilityData } from './usePairedMemberAvailability';
 export type { Group } from './useGroups';
 export type { GroupMember } from './useMembers';
 export type { PairResult } from './usePairings';

--- a/src/hooks/usePairedMemberAvailability.ts
+++ b/src/hooks/usePairedMemberAvailability.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export interface PairedPartner {
+  userId: string;
+  username: string;
+  availability: Record<string, string[]>; // date -> time slots
+}
+
+export interface PairedMemberAvailabilityData {
+  partners: PairedPartner[];
+  dinnerId: string | null;
+  hasPairing: boolean;
+  loading: boolean;
+  error: boolean;
+}
+
+export function usePairedMemberAvailability(groupId: string): PairedMemberAvailabilityData {
+  const [partners, setPartners] = useState<PairedPartner[]>([]);
+  const [dinnerId, setDinnerId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
+
+        // Find the current user's next upcoming dinner in this group
+        const { data: myDinnerRows } = await supabase
+          .from('peopledinner')
+          .select('dinners_dinnerid, dinners!inner(groups_groupid, dinner_date)')
+          .eq('users_userid', user.id)
+          .eq('dinners.groups_groupid', groupId)
+          .gte('dinners.dinner_date', new Date().toISOString())
+          .order('dinners.dinner_date', { ascending: true })
+          .limit(1);
+
+        if (!myDinnerRows || myDinnerRows.length === 0) return;
+
+        const myDinner = myDinnerRows[0];
+        setDinnerId(myDinner.dinners_dinnerid);
+
+        // Find the other members of that dinner
+        const { data: dinnerMembers } = await supabase
+          .from('peopledinner')
+          .select('users_userid, user_profiles:users_userid(username)')
+          .eq('dinners_dinnerid', myDinner.dinners_dinnerid)
+          .neq('users_userid', user.id);
+
+        if (!dinnerMembers || dinnerMembers.length === 0) return;
+
+        const partnerIds = dinnerMembers.map(m => m.users_userid);
+
+        // Get their general availability slots
+        const { data: slots } = await supabase
+          .from('availability_slots')
+          .select('user_id, available_date, time_slot')
+          .in('user_id', partnerIds)
+          .is('dinner_event_id', null);
+
+        const availMap: Record<string, Record<string, string[]>> = {};
+        for (const slot of slots ?? []) {
+          if (!availMap[slot.user_id]) availMap[slot.user_id] = {};
+          if (!availMap[slot.user_id][slot.available_date]) availMap[slot.user_id][slot.available_date] = [];
+          availMap[slot.user_id][slot.available_date].push(slot.time_slot);
+        }
+
+        setPartners(
+          dinnerMembers.map(m => ({
+            userId: m.users_userid,
+            username: (m.user_profiles as { username?: string } | null)?.username ?? 'Unknown',
+            availability: availMap[m.users_userid] ?? {},
+          }))
+        );
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, [groupId]);
+
+  return { partners, dinnerId, hasPairing: partners.length > 0, loading, error };
+}


### PR DESCRIPTION
## Summary

After a user saves their availability, they are now redirected to a dedicated confirmation page rather than receiving a brief toast. The confirmation page gives users a clear summary of what they submitted and — once pairings are created — shows their dinner partner's availability so they can see where schedules overlap.

---

## Changes

### New page: `/groups/[id]/availability/confirmation`
- Displays a **"Your Availability"** card summarising the dates and time slots the user just submitted
- If the user has an **active dinner pairing**, shows a per-partner card with their submitted availability (dates + time slots as chips)
- If **no pairing exists yet**, shows a "Waiting for Pairings" card explaining what to expect
- If the partner data **fails to load**, shows a distinct error card with a refresh prompt rather than silently falling back to the waiting state
- **"Back to Group"** (primary) and **"Edit Availability"** (secondary) action buttons — both use `useRouter` for navigation; no nested `<Link>` inside `<button>` or vice versa

### Updated: `/groups/[id]/availability` (the picker page)
- On successful save, redirects to the confirmation page instead of displaying a success toast
- Error-only inline message retained for save failures
- **Removed** the admin member submission summary card — that view belongs on the confirmation page, not the picker

### New hook: `usePairedMemberAvailability`
- Fetches the current user's next upcoming dinner in the group via `peopledinner → dinners`
- Resolves the other attendees of that dinner
- Fetches each partner's general availability slots (`dinner_event_id IS NULL`)
- Exposes `{ partners, dinnerId, hasPairing, loading, error }`
- Single `useEffect` with `try/catch/finally` — loading is always cleared even on failure

### New content file: `availabilityConfirmation.ts`
- All UI copy for the confirmation page in one place: section titles, waiting/error state messages, time slot labels, button labels

### `hooks/index.ts`
- Exports `usePairedMemberAvailability` and its public types

---

## UX Decisions

| Decision | Rationale |
|---|---|
| "Back to Group" is the primary (gold) button | The confirmation page is a resting point after task completion — the forward path is returning to the group |
| "Edit Availability" is secondary | Editing is a correction path, not the expected next step |
| Partner availability is only shown for your specific dinner | Users should only see the people they are actually paired with, not all group members |
| Waiting state instead of hiding the section | Keeps the page useful on first visit before pairings are created |

---

## Test Plan

- [ ] Save availability → confirm redirect to `/confirmation`
- [ ] Confirmation page shows correct dates and time slots you selected
- [ ] Time slot chips display human-readable labels (e.g. "Dinner (6–9pm)")
- [ ] If no active pairing: "Waiting for Pairings" card is shown
- [ ] If active pairing exists: partner card shows with their dates/slots (or "has not submitted yet" if they have not)
- [ ] "Edit Availability" navigates back to the picker with existing selections preserved
- [ ] "Back to Group" navigates to `/groups/[id]/manage`
- [ ] Visiting `/confirmation` directly without saving shows your current DB availability, not a blank state
- [ ] If save fails, error message appears on the picker page (no redirect)
